### PR TITLE
Add custom error messages for errors

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -100,6 +100,14 @@ defmodule Solicit.Response do
   @doc """
   Signifies an unauthorized request.
   """
+  @spec unauthorized(Plug.Conn.t(), list()) :: Plug.Conn.t()
+  def unauthorized(conn, errors) do
+    conn
+    |> put_status(:unauthorized)
+    |> json(%{errors: errors})
+    |> halt()
+  end
+
   @spec unauthorized(Plug.Conn.t()) :: Plug.Conn.t()
   def unauthorized(conn) do
     conn
@@ -112,6 +120,14 @@ defmodule Solicit.Response do
   @doc """
   Signifies a forbidden response.
   """
+  @spec forbidden(Plug.Conn.t(), list()) :: Plug.Conn.t()
+  def forbidden(conn, errors) do
+    conn
+    |> put_status(:forbidden)
+    |> json(%{errors: errors})
+    |> halt()
+  end
+
   @spec forbidden(Plug.Conn.t()) :: Plug.Conn.t()
   def forbidden(conn) do
     conn
@@ -124,6 +140,14 @@ defmodule Solicit.Response do
   @doc """
   Signifies a not found response.
   """
+  @spec not_found(Plug.Conn.t(), list()) :: Plug.Conn.t()
+  def not_found(conn, errors) do
+    conn
+    |> put_status(:not_found)
+    |> json(%{errors: errors})
+    |> halt()
+  end
+
   @spec not_found(Plug.Conn.t()) :: Plug.Conn.t()
   def not_found(conn) do
     conn
@@ -136,8 +160,15 @@ defmodule Solicit.Response do
   @doc """
   Signifies a conflicting response.
   """
-  @spec conflict(Plug.Conn.t(), binary()) :: Plug.Conn.t()
-  def conflict(conn, description) do
+  @spec conflict(Plug.Conn.t(), list() | binary()) :: Plug.Conn.t()
+  def conflict(conn, errors) when is_list(errors) do
+    conn
+    |> put_status(:conflict)
+    |> json(%{errors: errors})
+    |> halt()
+  end
+
+  def conflict(conn, description) when is_binary(description) do
     conn
     |> put_status(:conflict)
     |> json(%{errors: [ResponseError.conflict(description)]})
@@ -148,7 +179,10 @@ defmodule Solicit.Response do
   @doc """
   Signifies an unprocessable_entity response.
   """
-  @spec unprocessable_entity(Plug.Conn.t(), Ecto.Changeset.t() | binary() | Postgrex.Error.t()) ::
+  @spec unprocessable_entity(
+          Plug.Conn.t(),
+          Ecto.Changeset.t() | binary() | Postgrex.Error.t() | list()
+        ) ::
           Plug.Conn.t()
   def unprocessable_entity(conn, %Changeset{} = changeset) do
     conn
@@ -168,6 +202,13 @@ defmodule Solicit.Response do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{errors: [message]})
+    |> halt()
+  end
+
+  def unprocessable_entity(conn, errors) when is_list(errors) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{errors: errors})
     |> halt()
   end
 

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -106,6 +106,20 @@ defmodule Solicit.ResponseTest do
       |> Response.unauthorized()
       |> json_response(:unauthorized)
     end
+
+    test "Should return 401 with custom errors" do
+      response =
+        build_conn()
+        |> Response.unauthorized([
+          %{
+            code: "invalid",
+            description: "Invalid code"
+          }
+        ])
+        |> json_response(:unauthorized)
+
+      assert response == %{"errors" => [%{"code" => "invalid", "description" => "Invalid code"}]}
+    end
   end
 
   describe "forbidden" do
@@ -113,6 +127,56 @@ defmodule Solicit.ResponseTest do
       build_conn()
       |> Response.forbidden()
       |> json_response(:forbidden)
+    end
+
+    test "Should return 403 with custom errors" do
+      response =
+        build_conn()
+        |> Response.forbidden([
+          %{
+            code: "lockout",
+            description: "Too many attempts, please try again later"
+          }
+        ])
+        |> json_response(:forbidden)
+
+      assert response == %{
+               "errors" => [
+                 %{
+                   "code" => "lockout",
+                   "description" => "Too many attempts, please try again later"
+                 }
+               ]
+             }
+    end
+  end
+
+  describe "not_found" do
+    test "Should return 404" do
+      build_conn()
+      |> Response.not_found()
+      |> json_response(:not_found)
+    end
+
+    test "Should return 404 with custom errors" do
+      response =
+        build_conn()
+        |> Response.not_found([
+          %{
+            code: "not_found",
+            description: "Re-enter username and password"
+          }
+        ])
+        |> json_response(:not_found)
+
+      assert response == %{
+               "errors" => [
+                 %{
+                   "code" => "not_found",
+                   "description" => "Re-enter username and password"
+                 }
+               ]
+             }
     end
   end
 
@@ -125,6 +189,27 @@ defmodule Solicit.ResponseTest do
 
       assert response["errors"] == [%{"code" => "conflict", "description" => "test"}]
     end
+
+    test "Should return 409 with custom errors" do
+      response =
+        build_conn()
+        |> Response.conflict([
+          %{
+            code: "conflict",
+            description: "resolution"
+          }
+        ])
+        |> json_response(:conflict)
+
+      assert response == %{
+               "errors" => [
+                 %{
+                   "code" => "conflict",
+                   "description" => "resolution"
+                 }
+               ]
+             }
+    end
   end
 
   describe "unprocessable_entity" do
@@ -132,6 +217,27 @@ defmodule Solicit.ResponseTest do
       build_conn()
       |> Response.unprocessable_entity()
       |> json_response(:unprocessable_entity)
+    end
+
+    test "Should return 422 with custom errors" do
+      response =
+        build_conn()
+        |> Response.unprocessable_entity([
+          %{
+            code: "unprocessable_entity",
+            description: "This was an error"
+          }
+        ])
+        |> json_response(:unprocessable_entity)
+
+      assert response == %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "description" => "This was an error"
+                 }
+               ]
+             }
     end
   end
 


### PR DESCRIPTION
While implementing Solicit in CMW I found more use cases that needed to be handled. Namely custom error messages for errors instead of a standard response.