### PR TITLE
feat: Add accepted/1 Function to Response Package

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -52,6 +52,13 @@ defmodule Solicit.Response do
   @doc """
   Returns a successful accepted response. Normally used to signify that the request was accepted, but might not have finished processing.
   """
+  @spec accepted(Plug.Conn.t()) :: Plug.Conn.t()
+  def accepted(conn) do
+    conn
+    |> put_status(:accepted)
+    |> json(nil)
+  end
+
   @spec accepted(Plug.Conn.t(), any()) :: Plug.Conn.t()
   def accepted(conn, details) when is_binary(details) do
     conn

--- a/md/response.md
+++ b/md/response.md
@@ -45,6 +45,18 @@ This is used for a successful created response.
 
 Returns `Plug.Conn.t()` with a status of `201` and the result passed in as the payload.
 
+### Response.accepted/1
+
+Usage:
+
+This is used for an accepted response. Normally used to signify that the request was accepted, but might not have finished processing.
+
+```elixir
+  Response.accepted(conn)
+```
+
+Returns `Plug.Conn.t()` with a status of `202` and an empty payload.
+
 ### Response.accepted/2
 
 Usage:

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -75,7 +75,18 @@ defmodule Solicit.ResponseTest do
     end
   end
 
-  describe "accepted" do
+  describe "accepted/1" do
+    test "Should return 202" do
+      response =
+        build_conn()
+        |> Response.accepted()
+        |> json_response(:accepted)
+
+      assert response == nil
+    end
+  end
+
+  describe "accepted/2" do
     test "Should return 202" do
       response =
         build_conn()


### PR DESCRIPTION
Adds a new `Solicit.Response.accepted/1` function that does _not_ require `details` secondary parameter.