### PR TITLE
TECH: Validate Key Instead of NULL Data

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -480,7 +480,7 @@ defmodule Solicit.Response do
     :ok
   end
 
-  @spec process_fields(term(), term()) :: :ok | none()
+  @spec process_fields(term(), term()) :: :ok | none() | nil
   defp process_fields(_result, {_field, value}) when is_function(value), do: :ok
 
   defp process_fields(result, {field, sub_fields}) when is_list(sub_fields) do
@@ -497,7 +497,7 @@ defmodule Solicit.Response do
   end
 
   defp process_fields(result, field) do
-    if is_nil(Map.get(result, field)) do
+    unless Map.has_key?(result, field) do
       raise_fields_error()
     end
   end

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -499,6 +499,25 @@ defmodule Solicit.ResponseTest do
       |> json_response(:ok)
     end
 
+    test "Should allow nil values in the result " do
+      build_conn()
+      |> Response.ok(
+        %{
+          space_number: "Test",
+          vehicle: %{license_plate: "License Plate", state: nil}
+        },
+        [
+          :space_number,
+          vehicle: [
+            :license_plate,
+            :state,
+          ]
+        ]
+      )
+      |> json_response(:ok)
+    end
+
+
     test "Should return the correct shape for a list of sub structures when defined" do
       build_conn()
       |> Response.ok(


### PR DESCRIPTION
In `has_all_keys` we are validating whether the data is `nil` instead of validating if the key exists. This worked until we have a valid `key` that happens to have data that is `nil`.