### PR TITLE
TECH: Update Parsers Customer Response to Match Conventions

### DIFF
--- a/lib/plugs/parsers.ex
+++ b/lib/plugs/parsers.ex
@@ -13,7 +13,7 @@ defmodule Solicit.Plugs.Parsers do
     Parsers.call(conn, options)
   rescue
     _e in Parsers.ParseError ->
-      Solicit.Response.bad_request(conn, "Request is malformed")
+      Solicit.Response.bad_request(conn, "Request is malformed.")
 
     _e in Parsers.RequestTooLargeError ->
       Solicit.Response.request_entity_too_large(conn)
@@ -22,6 +22,6 @@ defmodule Solicit.Plugs.Parsers do
       Solicit.Response.unsupported_media_type(conn)
 
     _e in Parsers.BadEncodingError ->
-      Solicit.Response.bad_request(conn, "Request has bad encoding")
+      Solicit.Response.bad_request(conn, "Request has bad encoding.")
   end
 end


### PR DESCRIPTION
I noticed that we have periods at the end of messages and I wanted the Parsers custom responses to match our defaults