### PR TITLE
Support arrays in QueryParams Validation

### DIFF
--- a/lib/plugs/query_params_validator.ex
+++ b/lib/plugs/query_params_validator.ex
@@ -13,7 +13,7 @@ defmodule Solicit.Plugs.Validation.QueryParams do
   def call(%Plug.Conn{query_params: query_params} = conn, _options) when query_params != %{} do
     filtered_params =
       Enum.reduce(query_params, %{}, fn {key, value}, acc ->
-        if byte_size(value) > 0 do
+        if is_list(value) or byte_size(value) > 0 do
           Map.put(acc, key, value)
         else
           acc

--- a/test/query_params_validator_test.exs
+++ b/test/query_params_validator_test.exs
@@ -44,6 +44,51 @@ defmodule Solicit.Plugs.Validation.QueryParamsTest do
       assert conn == QueryParams.call(conn, %{})
     end
 
+    test "query params is array - [] and has values" do
+      conn =
+        build_conn(:get, "?test[]=123&test[]=abc123")
+        |> Plug.Conn.fetch_query_params()
+        |> struct(body_params: %{})
+
+      assert conn == QueryParams.call(conn, %{})
+    end
+
+    test "query params is array - [] and no values" do
+      conn =
+        build_conn(:get, "?test[]=&test[]=")
+        |> Plug.Conn.fetch_query_params()
+        |> struct(body_params: %{})
+
+      assert conn == QueryParams.call(conn, %{})
+    end
+
+    test "query params is array - [] encoded and has a value" do
+      conn =
+        build_conn(:get, "?test=%5B1%5D")
+        |> Plug.Conn.fetch_query_params()
+        |> struct(body_params: %{})
+
+      assert conn == QueryParams.call(conn, %{})
+    end
+
+    test "query params is array - [] encoded and no values" do
+      conn =
+        build_conn(:get, "?test=%5B%5D")
+        |> Plug.Conn.fetch_query_params()
+        |> struct(body_params: %{})
+
+      assert conn == QueryParams.call(conn, %{})
+    end
+
+    test "query params is array - comma separated list" do
+      conn =
+        build_conn(:get, "?test=123,abc123")
+        |> Plug.Conn.fetch_query_params()
+        |> struct(body_params: %{})
+
+      assert conn == QueryParams.call(conn, %{})
+    end
+
     test "no query params" do
       conn = Plug.Conn.fetch_query_params(build_conn())
 


### PR DESCRIPTION
Arrays are silly. Address arrays in query params

Sentry error from CMW: https://sentry.io/organizations/smartrent/issues/2406816688/?project=205281