### PR TITLE
Tech: Add Static Wrapper Plug

### DIFF
--- a/lib/plugs/static.ex
+++ b/lib/plugs/static.ex
@@ -1,0 +1,17 @@
+defmodule Solicit.Plugs.Static do
+  @moduledoc """
+  Creates a wrapper around Plug.Static to catch Invalid Path Errors.
+
+  See Plug.Parsers documentation
+  """
+  alias Plug.Static
+
+  def init(opts), do: Static.init(opts)
+
+  def call(conn, opts) do
+    Static.call(conn, opts)
+  rescue
+    _e in Static.InvalidPathError ->
+      Solicit.Response.bad_request(conn, "Invalid path for static asset.")
+  end
+end

--- a/test/plugs/static_test.exs
+++ b/test/plugs/static_test.exs
@@ -1,0 +1,31 @@
+defmodule Solicit.Plugs.StaticTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+
+  alias Solicit.Plugs.Static
+
+  @default_opts %{
+    at: [],
+    from: {:solicit, "priv/static"},
+    gzip?: false,
+    brotli?: false,
+    only_rules: {~w(css fonts images js favicon.ico robots.txt), []}
+  }
+
+  test "Throws :bad_request is path is invalid" do
+    build_conn(:get, "/")
+    |> struct(path_info: ["images", "%20%0d%0a%3Csvg%2fonload%3dalert%281%29%0d%0a%0d%0a"])
+    |> Static.call(@default_opts)
+    |> json_response(:bad_request)
+  end
+
+  test "Does not throw an error if path is valid" do
+    conn =
+      build_conn(:get, "/")
+      |> struct(path_info: [])
+      |> Static.call(@default_opts)
+
+    assert conn.path_info == []
+  end
+end


### PR DESCRIPTION
Adding a Static Wrapper Plug to handle Invalid Static Asset Path.

Run Tests

![image](https://user-images.githubusercontent.com/29756611/122823615-98d1e600-d2ad-11eb-8cf3-0ff3d3a55206.png)
