### PR TITLE
feat: unprocessable_entity fallback

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -331,6 +331,13 @@ defmodule Solicit.Response do
     |> halt()
   end
 
+  def unprocessable_entity(conn, _errors) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> json(%{errors: [ResponseError.unprocessable_entity()]})
+    |> halt()
+  end
+
   @spec unprocessable_entity(Plug.Conn.t()) :: Plug.Conn.t()
   def unprocessable_entity(conn) do
     conn

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -460,6 +460,22 @@ defmodule Solicit.ResponseTest do
                ]
              }
     end
+
+    test "Should return base 422 messaging if provided a bad 2nd argument" do
+      response =
+        build_conn()
+        |> Response.unprocessable_entity(nil)
+        |> json_response(:unprocessable_entity)
+
+      assert response == %{
+               "errors" => [
+                 %{
+                   "code" => "unprocessable_entity",
+                   "description" => "Unable to process change."
+                 }
+               ]
+             }
+    end
   end
 
   describe "too_many_requests" do


### PR DESCRIPTION
Given a bad 2nd arg for errors, fallback to the 422 templated message as if nothing was passed in

Sentry error: https://sentry.io/organizations/smartrent/issues/2311962944/?project=205281&referrer=slack