### PR TITLE
TECH-1067: Update Elixir and OTP version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.0.2
-elixir 1.12.1-otp-24
+erlang 24.0.4
+elixir 1.12.2-otp-24


### PR DESCRIPTION
This shouldn't matter much here, but just getting this updated to the version dependencies our other main apps use.

Github CI on this already uses a newer version.
![Screen Shot 2021-09-15 at 11 21 42 AM](https://user-images.githubusercontent.com/195006/133488234-a62f00dd-86b5-464d-90ab-d8202f3c5dd2.png)

![Screen Shot 2021-09-15 at 11 22 44 AM](https://user-images.githubusercontent.com/195006/133488363-1e2753d8-57c8-481a-b8f9-94808b52af56.png)
