### PR TITLE
Add support for atoms to Response.unprocessable_entity/2

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -317,7 +317,7 @@ defmodule Solicit.Response do
     |> halt()
   end
 
-  def unprocessable_entity(conn, message) when is_binary(message) do
+  def unprocessable_entity(conn, message) when is_binary(message) or is_atom(message) do
     conn
     |> put_status(:unprocessable_entity)
     |> json(%{errors: [message]})

--- a/test/response_test.exs
+++ b/test/response_test.exs
@@ -139,6 +139,12 @@ defmodule Solicit.ResponseTest do
       |> Response.bad_request()
       |> json_response(:bad_request)
     end
+
+    test "Should return 400 with atoms" do
+      build_conn()
+      |> Response.bad_request(:error)
+      |> json_response(:bad_request)
+    end
   end
 
   describe "unauthorized" do
@@ -498,6 +504,12 @@ defmodule Solicit.ResponseTest do
                  }
                ]
              }
+    end
+
+    test "Should return 422 with atoms" do
+      build_conn()
+      |> Response.unprocessable_entity(:error)
+      |> json_response(:unprocessable_entity)
     end
   end
 


### PR DESCRIPTION
We've had a few problems lately in CMW with this throwing FunctionClauseErrors.

[CMW-6206](https://smartrent.atlassian.net/browse/CMW-6206)

[CMW-6206]: https://smartrent.atlassian.net/browse/CMW-6206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ