### PR TITLE
Add atom() to Response.unprocessible_entity/2 typespec

### DIFF
--- a/lib/response.ex
+++ b/lib/response.ex
@@ -300,7 +300,7 @@ defmodule Solicit.Response do
   """
   @spec unprocessable_entity(
           Plug.Conn.t(),
-          Ecto.Changeset.t() | binary() | Postgrex.Error.t() | list()
+          Ecto.Changeset.t() | binary() | atom() | Postgrex.Error.t() | list()
         ) ::
           Plug.Conn.t()
   def unprocessable_entity(conn, %Changeset{} = changeset) do


### PR DESCRIPTION
[Atoms are allowed](https://github.com/smartrent/solicit/blob/main/lib/response.ex#L320) for `Solicit.Response.unprocessible_entity/2`, but the typespec does not allow it. This change will make Dialyzer happy for me 😄 