### PR TITLE
cast changeset errors even if they have other metadata attached

### DIFF
--- a/lib/changeset.ex
+++ b/lib/changeset.ex
@@ -7,11 +7,24 @@ defmodule Solicit.Changeset do
   A module encapsulating the translation layer between a changeset error and the JSON error shape returned in an API response.
   """
   @spec code_and_description(tuple()) :: tuple()
-  def code_and_description({description, [error_code: error_code]}),
-    do: {error_code, description}
-
-  def code_and_description({description, [validation: error_code]}),
-    do: {error_code, description}
-
+    def code_and_description({description, list}) when is_list(list) do
+    list
+    |> Keyword.fetch(:error_code)
+    |> case do
+      :error ->
+        Keyword.fetch(list, :validation)
+      
+      result ->
+        result
+    end
+    |> case do
+      :error ->
+        {:unknown_error, description}
+      
+      {:ok, error_code} ->
+        {error_code, description}
+    end
+  end
+  
   def code_and_description({changeset_error, _}), do: {:unknown_error, changeset_error}
 end


### PR DESCRIPTION
I've noticed this for a while but it's not a big problem... but I think the reason why a lot of our changeset error codes get translated to `"unknown_error"` is because the keyword list in the changeset can include other properties. It would be nice to probably also send those to the frontend really -- for example, if the error is "Name is limited to 100 characters", returning the max characters in the payload is helpful for localization e.g. `"code": "max_length", "message": "Name is limited to 100 characters", "validation": { "max_length": 100 }`

note: untested, just wrote in GitHub editor directly as a proposal 😬 